### PR TITLE
Allow setting multiple docker-compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ The SSH port to be used. Default is 22.
 
 ### `stack_file_name`
 
-Docker stack file used. Default is docker-compose.yml
+Docker stack file(s) used. Can be several files seperated by commas that
+will be passed to docker-compose in order. Default is running
+docker-compose without any -f flags (which will use docker-compose.yml overriden
+by docker-compose.override.yml if there is one).
 
 ### `docker_login_user`
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,11 @@ inputs:
     description: Deployment command args.
     required: true
   stack_file_name:
-    description: Docker stack file used. Default is docker-compose.yaml
+    description: |
+      Docker stack file(s) used. Can be several files seperated by commas that
+      will be passed to docker-compose in order. Default is running
+      docker-compose without any -f flags (which will use docker-compose.yml overriden
+      by docker-compose.override.yml if there is one).
     required: false
   ssh_port:
     description: The ssh port of the server. Default is 22

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,18 +29,19 @@ if [ -z "$INPUT_ARGS" ]; then
 fi
 
 if [ -z "$INPUT_STACK_FILE_NAME" ]; then
-  INPUT_STACK_FILE_NAME=docker-compose.yml
+  DEPLOYMENT_COMMAND="docker-compose"
+else
+  # convert comma seperated filenames to docker-compose -f
+  # 'a,b,c' -> '-f a -f b -f c'
+  DOCKER_COMPOSE_FILE_FLAGS="$(echo "$INPUT_STACK_FILE_NAME" | sed 's/^/-f /' | sed 's/,/ -f /')"
+  DEPLOYMENT_COMMAND="docker-compose $DOCKER_COMPOSE_FILE_FLAGS"
 fi
 
 if [ -z "$INPUT_SSH_PORT" ]; then
   INPUT_SSH_PORT=22
 fi
 
-STACK_FILE=${INPUT_STACK_FILE_NAME}
 DEPLOYMENT_COMMAND_OPTIONS="--host ssh://$INPUT_REMOTE_DOCKER_HOST:$INPUT_SSH_PORT"
-
-DEPLOYMENT_COMMAND="docker-compose -f $STACK_FILE"
-
 
 SSH_HOST=${INPUT_REMOTE_DOCKER_HOST#*@}
 


### PR DESCRIPTION
Hey, I needed to use multiple .yml files so I implemented this. It's been [running successfully](https://github.com/kitspace/kitspace-v2/runs/2261078573?check_suite_focus=true#step:7:1323) from [this yaml](https://github.com/kitspace/kitspace-v2/blob/d2825ac29e6426be335383071427477f76d2bb01/.github/workflows/publish-docker-images.yml#L131-L156). 

It does change one behavior slightly. By default it now calls docker-compose without any `-f` arguments if `stack_file_name` is empty. So it's falling back to the docker-compose built-in defaults (which are `docker-compose.yml` extended by `docker-compose.override.yml` I recently learned). Hence I would suggest a major version bump if you decide to merge this. 