### PR TITLE
Remove docker context at the end of the run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://taptap21/docker-remote-deployment-action:v1.1
+  image: 'Dockerfile'
 
 
 branding:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -78,4 +78,6 @@ ${DEPLOYMENT_COMMAND} ${DEPLOYMENT_COMMAND_OPTIONS} pull
 echo "Command: ${DEPLOYMENT_COMMAND} ${INPUT_ARGS}"
 ${DEPLOYMENT_COMMAND} ${DEPLOYMENT_COMMAND_OPTIONS} ${INPUT_ARGS}
 
+echo "Remove docker context"
+docker context rm staging
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -79,5 +79,5 @@ echo "Command: ${DEPLOYMENT_COMMAND} ${INPUT_ARGS}"
 ${DEPLOYMENT_COMMAND} ${DEPLOYMENT_COMMAND_OPTIONS} ${INPUT_ARGS}
 
 echo "Remove docker context"
-docker context rm staging
+docker context rm -f staging
 


### PR DESCRIPTION
If running on a self-hosted runner, the docker context continue existing, and further actions crashes.

This removes the context at the end of the run.